### PR TITLE
Sticky categories list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /node_modules
 /.pnp
 .pnp.js
+pnpm-lock.yaml
 
 # testing
 /coverage

--- a/src/pages/commands.tsx
+++ b/src/pages/commands.tsx
@@ -67,15 +67,17 @@ const Commands: NextPage<Props> = ({ categories, commands }) => {
     view = (
       <>
         <Col md={3}>
-          <h3>
-            <strong>Categories</strong>
-          </h3>
-          <p className="category-note">{currentCategory.Note}</p>
+          <div className="sticky">
+            <h3>
+              <strong>Categories</strong>
+            </h3>
+            <p className="category-note">{currentCategory.Note}</p>
 
-          <div id="categories">
-            <ul id="categories-list" className="list-unstyled">
-              {categoriesComponents}
-            </ul>
+            <div id="categories">
+              <ul id="categories-list" className="list-unstyled">
+                {categoriesComponents}
+              </ul>
+            </div>
           </div>
         </Col>
 

--- a/src/style.css
+++ b/src/style.css
@@ -99,12 +99,23 @@ body {
 	border-radius: 10px;
 }
 
+.sticky {
+	position: -webkit-sticky;
+	position: sticky;
+	top: 0;
+}
+
 #categories-list {
 	width: 100%;
 	margin: 0;
 }
 
 @media (max-width: 768px) {
+	.sticky {
+		position: initial;
+		top: initial;
+	}
+
 	#categories-list {
 		columns: 2;
 	}


### PR DESCRIPTION
Makes the categories list sticky so that you can see it when you scroll down. Disabled on mobile because the categories list is at the top, not in a sidebar.

![image](https://user-images.githubusercontent.com/46797041/116030859-9fc6e880-a6b0-11eb-8ea0-07b9e5bd227e.png)
